### PR TITLE
Remove --privileged from contrail-status

### DIFF
--- a/containers/node-init/contrail-status-init.sh
+++ b/containers/node-init/contrail-status-init.sh
@@ -41,7 +41,7 @@ if [[ -n "${SERVER_CA_CERTFILE}" ]] && [[ -e ${SERVER_CA_CERTFILE} ]] ; then
   fi
 fi
 tmp_argv="/root/contrail-status.py \$cmd_args \$@"
-tmp_suffix="--rm --pid host --net host --privileged ${CONTRAIL_STATUS_IMAGE} \${tmp_argv}"
+tmp_suffix="--rm --pid host --net host ${CONTRAIL_STATUS_IMAGE} \${tmp_argv}"
 
 u=\$(which docker 2>/dev/null)
 if pidof dockerd >/dev/null 2>&1 || pidof dockerd-current >/dev/null 2>&1 ; then

--- a/containers/node-init/contrail-tools-init.sh
+++ b/containers/node-init/contrail-tools-init.sh
@@ -26,7 +26,7 @@ if [[ -e /etc/contrail ]] ; then
 fi
 
 image=$(echo ${CONTRAIL_STATUS_IMAGE} | sed 's/contrail-status:/contrail-tools:/')
-tmp_suffix="--rm --pid host --net host --privileged ${image}"
+tmp_suffix="--rm --pid host --net host ${image}"
 tmp_file=/host/usr/bin/contrail-tools.tmp.${RANDOM}
 cat > $tmp_file << EOM
 #!/bin/bash


### PR DESCRIPTION
In later versions of podman, --privileged cannot be called with
--cap-add resulting in an error and the container fails to
start. Remove this as --cap-add=ALL is called later.